### PR TITLE
Use prebundled facilmap-server 3.1.0 release from NPM

### DIFF
--- a/conf/app.src
+++ b/conf/app.src
@@ -1,7 +1,0 @@
-SOURCE_URL=https://github.com/FacilMap/facilmap/archive/refs/tags/v3.0.1.tar.gz
-SOURCE_SUM=0cc1a92dc7be0e8dca605ebeaf3874f0f34fea8f6b830ebbe299a3c0deac291d
-SOURCE_SUM_PRG=sha256sum
-SOURCE_FORMAT=tar.gz
-SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=
-SOURCE_EXTRACT=true

--- a/conf/config.env
+++ b/conf/config.env
@@ -16,7 +16,7 @@ DB_PASSWORD=__DB_PWD__
 
 # OpenRouteService is used for calculating routes with advanced settings
 # Get a token on https://go.openrouteservice.org/
-OSR_TOKEN=__OSR_TOKEN__
+ORS_TOKEN=__ORS_TOKEN__
 
 # MapBox is used for calculating routes with simple settings
 # Get an API key on https://www.mapbox.com/signup/

--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -5,11 +5,12 @@ After=network.target
 [Service]
 Type=simple
 Environment=NODE_ENV=production
+Environment=DOTENV_CONFIG_PATH=__FINALPATH__/etc/facilmap.env
 User=__APP__
 Group=__APP__
 Environment="__YNH_NODE_LOAD_PATH__"
-ExecStart=/bin/sh -c ' yarn server'
-WorkingDirectory=__FINALPATH__/server/
+ExecStart=__FINALPATH__/bin/facilmap-server
+WorkingDirectory=__FINALPATH__
 StandardOutput=syslog
 StandardError=syslog
 SyslogIdentifier=__APP__

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Collaborative maps and routing with a straightforward interface",
         "fr": "Carte collaborative avec une interface simple et pratique"
     },
-    "version": "3.0.1~ynh1",
+    "version": "3.1.0~ynh1",
     "url": "https://github.com/FacilMap/facilmap",
     "license": "AGPL-3.0",
     "maintainer": {
@@ -49,7 +49,7 @@
               }
             },
             {
-                "name": "osr_token",
+                "name": "ors_token",
                 "type": "string",
                 "help": {
                     "en": "OpenRouteService is used for calculating routes with advanced settings. You can get a token on https://go.openrouteservice.org/",
@@ -84,7 +84,7 @@
             },
             {
                 "name": "maxmind_license_key",
-                "type": "password",
+                "type": "string",
                 "help": {
                     "en": "License key associated to the maxmind user id you specified.",
                     "fr": "La clé de license associée à l'utilisateur maxmind que vous avez spécifié."

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -8,10 +8,40 @@
 pkg_dependencies=""
 
 nodejs_version=14
+facilmap_version=3.1.0
 
 #=================================================
 # PERSONAL HELPERS
 #=================================================
+
+facilmap_add_config() {
+    mkdir -p "$final_path/etc"
+    ynh_add_config --template="../conf/config.env" --destination="$final_path/etc/facilmap.env"
+}
+
+facilmap_set_permissions() {
+    chown -R root:root $final_path
+    mkdir -p "$final_path/lib/node_modules/facilmap-server/cache"
+    chown -R facilmap:facilmap "$final_path/lib/node_modules/facilmap-server/cache"
+}
+
+facilmap_install_app() {
+    chown -R "$app":"$app" $final_path
+
+    pushd "$final_path"
+        ynh_exec_as "$app" "$ynh_node_load_PATH" "$ynh_npm" install --prefix "$final_path" -g facilmap-server@"$facilmap_version"
+    popd
+}
+
+facilmap_create_user() {
+    ynh_system_user_create --username=$app --home_dir="$final_path"
+    mkdir -p "$final_path"
+}
+
+facilmap_create_db() {
+    ynh_mysql_setup_db --db_user=$db_user --db_name=$db_name --db_pwd=$db_pwd
+    echo "ALTER DATABASE $db_name CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci" | ynh_mysql_connect_as --user=$db_user --password=$db_pwd --database=$db_name
+}
 
 #=================================================
 # EXPERIMENTAL HELPERS

--- a/scripts/install
+++ b/scripts/install
@@ -31,7 +31,7 @@ is_public=$YNH_APP_ARG_IS_PUBLIC
 user_agent="$YNH_APP_ARG_USER_AGENT"
 
 # APIS TOKENS
-osr_token="$YNH_APP_ARG_OSR_TOKEN"
+ors_token="$YNH_APP_ARG_ORS_TOKEN"
 mapbox_token="$YNH_APP_ARG_MAPBOX_TOKEN"
 mapzen_token="$YNH_APP_ARG_MAPZEN_TOKEN"
 maxmind_user_id="$YNH_APP_ARG_MAXMIND_USER_ID"
@@ -58,7 +58,7 @@ ynh_script_progression --message="Storing installation settings..." --weight=1
 ynh_app_setting_set --app=$app --key=domain --value=$domain
 ynh_app_setting_set --app=$app --key=path --value=$path_url
 ynh_app_setting_set --app=$app --key=user_agent --value=$user_agent
-ynh_app_setting_set --app=$app --key=osr_token --value=$osr_token
+ynh_app_setting_set --app=$app --key=ors_token --value=$ors_token
 ynh_app_setting_set --app=$app --key=mapbox_token --value=$mapbox_token
 ynh_app_setting_set --app=$app --key=mapzen_token --value=$mapzen_token
 ynh_app_setting_set --app=$app --key=maxmind_user_id --value=$maxmind_user_id
@@ -97,9 +97,6 @@ ynh_script_progression --message="Installing NodeJS..." --time --weight=15
 
 ynh_install_nodejs --nodejs_version=$nodejs_version
 
-# Install Yarn
-ynh_install_extra_app_dependencies --repo="deb https://dl.yarnpkg.com/debian/ stable main" --package="yarn" --key="https://dl.yarnpkg.com/debian/pubkey.gpg"
-
 #=================================================
 # CREATE A MYSQL DATABASE
 #=================================================
@@ -107,21 +104,19 @@ ynh_script_progression --message="Creating a MySQL database..." --time --weight=
 
 db_name=$(ynh_sanitize_dbid --db_name=$app)
 db_user=$db_name
+db_pwd= # Will be set by facilmap_create_db
 ynh_app_setting_set --app=$app --key=db_name --value=$db_name
-ynh_mysql_setup_db --db_user=$db_user --db_name=$db_name
-echo "ALTER DATABASE $db_name CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci" | ynh_mysql_connect_as --user=$db_user --password=$db_pwd --database=$db_name
+facilmap_create_db
 
 #=================================================
 # DOWNLOAD, CHECK AND UNPACK SOURCE
 #=================================================
-ynh_script_progression --message="Setting up source files..." --time --weight=1
+#ynh_script_progression --message="Setting up source files..." --time --weight=1
 
 ynh_app_setting_set --app=$app --key=final_path --value=$final_path
-# Download, check integrity, uncompress and patch the source from app.src
-ynh_setup_source --dest_dir="$final_path"
 
-# Remove docs, they are not needed and take a lot of space
-rm -rf "$final_path/docs"
+# Download, check integrity, uncompress and patch the source from app.src
+#ynh_setup_source --dest_dir="$final_path"
 
 #=================================================
 # NGINX CONFIGURATION
@@ -137,7 +132,7 @@ ynh_add_nginx_config
 ynh_script_progression --message="Configuring system user..." --time --weight=1
 
 # Create a system user
-ynh_system_user_create --username=$app --home_dir="/home/$app"
+facilmap_create_user
 
 #=================================================
 # SPECIFIC SETUP
@@ -146,13 +141,7 @@ ynh_system_user_create --username=$app --home_dir="/home/$app"
 #=================================================
 ynh_script_progression --message="Building node dependencies..." --time --weight=1
 
-chown -R "$app":"$app" $final_path
-
-pushd "$final_path"
-	ynh_use_nodejs
-	sudo -u $app env $ynh_node_load_PATH yarn install
-	sudo -u $app env $ynh_node_load_PATH yarn build
-popd
+facilmap_install_app
 
 #=================================================
 # SETUP SYSTEMD
@@ -166,7 +155,7 @@ ynh_add_systemd_config --others_var="ynh_node_load_PATH"
 # ADD A CONFIGURATION
 #=================================================
 
-ynh_add_config --template="../conf/config.env" --destination="$final_path/config.env"
+facilmap_add_config
 
 #=================================================
 # GENERIC FINALIZATION
@@ -174,8 +163,8 @@ ynh_add_config --template="../conf/config.env" --destination="$final_path/config
 # SECURE FILES AND DIRECTORIES
 #=================================================
 
-# Make only server/cache subdirectory accessible to facilmap to write
-chown -R root:root $final_path && chown -R $app:$app $final_path/server/cache
+# Set permissions on app files
+facilmap_set_permissions
 
 #=================================================
 # SETUP LOGROTATE

--- a/scripts/restore
+++ b/scripts/restore
@@ -65,14 +65,16 @@ ynh_restore_file --origin_path="$final_path"
 ynh_script_progression --message="Recreating the dedicated system user..." --time --weight=1
 
 # Create the dedicated user (if not existing)
-ynh_system_user_create --username=$app --home_dir="/home/$app"
+ynh_system_user_create --username=$app --home_dir="$final_path"
 
 #=================================================
 # RESTORE USER RIGHTS
 #=================================================
 
 # Restore permissions on app files
-chown -R root:root $final_path && chown -R $app:$app $final_path/server/cache
+chown -R root:root $final_path
+mkdir -p "$final_path/lib/node_modules/facilmap-server/cache"
+chown -R facilmap:facilmap "$final_path/lib/node_modules/facilmap-server/cache"
 
 #=================================================
 # SPECIFIC RESTORATION
@@ -91,17 +93,14 @@ ynh_script_progression --message="Installing NodeJS..." --time --weight=15
 
 ynh_install_nodejs --nodejs_version=$nodejs_version
 
-# Reinstall Yarn
-ynh_install_extra_app_dependencies --repo="deb https://dl.yarnpkg.com/debian/ stable main" --package="yarn" --key="https://dl.yarnpkg.com/debian/pubkey.gpg"
-
 #=================================================
 # RESTORE THE MYSQL DATABASE
 #=================================================
 ynh_script_progression --message="Restoring the MySQL database..." --time --weight=1
 
 db_pwd=$(ynh_app_setting_get --app=$app --key=mysqlpwd)
-ynh_mysql_setup_db --db_user=$db_user --db_name=$db_name --db_pwd=$db_pwd
-echo "ALTER DATABASE $db_name CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci" | ynh_mysql_connect_as --user=$db_user --password=$db_pwd --database=$db_name
+
+facilmap_create_db
 ynh_mysql_connect_as --user=$db_user --password=$db_pwd --database=$db_name < ./db.sql
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -26,7 +26,7 @@ db_pwd=$(ynh_app_setting_get --app=$app --key=mysqlpwd)
 
 # APIS TOKENS AND USER AGENT (USEFUL TO RESTORE CONFIG FILE)
 user_agent=$(ynh_app_setting_get --app=$app --key=user_agent)
-osr_token=$(ynh_app_setting_get --app=$app --key=osr_token)
+ors_token=$(ynh_app_setting_get --app=$app --key=ors_token)
 mapbox_token=$(ynh_app_setting_get --app=$app --key=mapbox_token)
 mapzen_token=$(ynh_app_setting_get --app=$app --key=mapzen_token)
 maxmind_user_id=$(ynh_app_setting_get --app=$app --key=maxmind_user_id)
@@ -65,16 +65,13 @@ ynh_systemd_action --service_name=$app --action="stop" --log_path="systemd"
 # DOWNLOAD, CHECK AND UNPACK SOURCE
 #=================================================
 
-if [ "$upgrade_type" == "UPGRADE_APP" ]
-then
-	ynh_script_progression --message="Upgrading source files..." --time --weight=1
-
-	# Download, check integrity, uncompress and patch the source from app.src
-	ynh_setup_source --dest_dir="$final_path"
-
-	# Remove docs, they are not needed and take a lot of space
-	rm -rf "$final_path/docs"
-fi
+#if [ "$upgrade_type" == "UPGRADE_APP" ]
+#then
+#	ynh_script_progression --message="Upgrading source files..." --time --weight=1
+#
+#	# Download, check integrity, uncompress and patch the source from app.src
+#	ynh_setup_source --dest_dir="$final_path"
+#fi
 
 #=================================================
 # NGINX CONFIGURATION
@@ -98,16 +95,13 @@ ynh_script_progression --message="Installing NodeJS..." --weight=15
 
 ynh_install_nodejs --nodejs_version=$nodejs_version
 
-# Install Yarn
-ynh_install_extra_app_dependencies --repo="deb https://dl.yarnpkg.com/debian/ stable main" --package="yarn" --key="https://dl.yarnpkg.com/debian/pubkey.gpg"
-
 #=================================================
 # CREATE DEDICATED USER
 #=================================================
 ynh_script_progression --message="Making sure dedicated system user exists..." --time --weight=1
 
 # Create a dedicated user (if not existing)
-ynh_system_user_create --username=$app --home_dir="/home/$app/"
+facilmap_create_user
 
 #=================================================
 # SPECIFIC UPGRADE
@@ -116,13 +110,7 @@ ynh_system_user_create --username=$app --home_dir="/home/$app/"
 #=================================================
 ynh_script_progression --message="Building node dependencies..." --weight=90
 
-chown -R "$app":"$app" $final_path
-
-pushd "$final_path"
-	ynh_use_nodejs
-	sudo -u $app env $ynh_node_load_PATH yarn install
-	sudo -u $app env $ynh_node_load_PATH yarn build
-popd
+facilmap_install_app
 
 #=================================================
 # SETUP SYSTEMD
@@ -136,7 +124,7 @@ ynh_add_systemd_config --others_var="ynh_node_load_PATH"
 # UPDATE A CONFIG FILE
 #=================================================
 
-ynh_add_config --template="../conf/config.env" --destination="$final_path/config.env"
+facilmap_add_config
 
 #=================================================
 # GENERIC FINALIZATION
@@ -145,7 +133,7 @@ ynh_add_config --template="../conf/config.env" --destination="$final_path/config
 #=================================================
 
 # Set permissions on app files
-chown -R root:root $final_path && chown -R $app:$app $final_path/server/cache
+facilmap_set_permissions
 
 #=================================================
 # SETUP LOGROTATE


### PR DESCRIPTION
FacilMap 3.1.0 now supports running the published NPM packages directly ([docs](https://docs.facilmap.org/developers/server/standalone.html#run-the-latest-release)).

This Pull Request updates the package to install and run the facilmap-server NPM package directly, rather than downloading the source code from GitHub and bundling it by hand. The installation process should now be much faster and hopefully take less memory.