### PR TITLE
4.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ It shall NOT be edited by hand.
 
 # Facilmap for YunoHost
 
-[![Integration level](https://dash.yunohost.org/integration/facilmap.svg)](https://dash.yunohost.org/appci/app/facilmap) ![Working status](https://ci-apps.yunohost.org/ci/badges/facilmap.status.svg) ![Maintenance status](https://ci-apps.yunohost.org/ci/badges/facilmap.maintain.svg)
+[![Integration level](https://dash.yunohost.org/integration/facilmap.svg)](https://ci-apps.yunohost.org/ci/apps/facilmap/) ![Working status](https://ci-apps.yunohost.org/ci/badges/facilmap.status.svg) ![Maintenance status](https://ci-apps.yunohost.org/ci/badges/facilmap.maintain.svg)
 
 [![Install Facilmap with YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=facilmap)
 

--- a/README_es.md
+++ b/README_es.md
@@ -5,7 +5,7 @@ No se debe editar a mano.
 
 # Facilmap para Yunohost
 
-[![Nivel de integración](https://dash.yunohost.org/integration/facilmap.svg)](https://dash.yunohost.org/appci/app/facilmap) ![Estado funcional](https://ci-apps.yunohost.org/ci/badges/facilmap.status.svg) ![Estado En Mantención](https://ci-apps.yunohost.org/ci/badges/facilmap.maintain.svg)
+[![Nivel de integración](https://dash.yunohost.org/integration/facilmap.svg)](https://ci-apps.yunohost.org/ci/apps/facilmap/) ![Estado funcional](https://ci-apps.yunohost.org/ci/badges/facilmap.status.svg) ![Estado En Mantención](https://ci-apps.yunohost.org/ci/badges/facilmap.maintain.svg)
 
 [![Instalar Facilmap con Yunhost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=facilmap)
 

--- a/README_eu.md
+++ b/README_eu.md
@@ -5,7 +5,7 @@ EZ editatu eskuz.
 
 # Facilmap YunoHost-erako
 
-[![Integrazio maila](https://dash.yunohost.org/integration/facilmap.svg)](https://dash.yunohost.org/appci/app/facilmap) ![Funtzionamendu egoera](https://ci-apps.yunohost.org/ci/badges/facilmap.status.svg) ![Mantentze egoera](https://ci-apps.yunohost.org/ci/badges/facilmap.maintain.svg)
+[![Integrazio maila](https://dash.yunohost.org/integration/facilmap.svg)](https://ci-apps.yunohost.org/ci/apps/facilmap/) ![Funtzionamendu egoera](https://ci-apps.yunohost.org/ci/badges/facilmap.status.svg) ![Mantentze egoera](https://ci-apps.yunohost.org/ci/badges/facilmap.maintain.svg)
 
 [![Instalatu Facilmap YunoHost-ekin](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=facilmap)
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -5,7 +5,7 @@ Il NE doit PAS être modifié à la main.
 
 # Facilmap pour YunoHost
 
-[![Niveau d’intégration](https://dash.yunohost.org/integration/facilmap.svg)](https://dash.yunohost.org/appci/app/facilmap) ![Statut du fonctionnement](https://ci-apps.yunohost.org/ci/badges/facilmap.status.svg) ![Statut de maintenance](https://ci-apps.yunohost.org/ci/badges/facilmap.maintain.svg)
+[![Niveau d’intégration](https://dash.yunohost.org/integration/facilmap.svg)](https://ci-apps.yunohost.org/ci/apps/facilmap/) ![Statut du fonctionnement](https://ci-apps.yunohost.org/ci/badges/facilmap.status.svg) ![Statut de maintenance](https://ci-apps.yunohost.org/ci/badges/facilmap.maintain.svg)
 
 [![Installer Facilmap avec YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=facilmap)
 

--- a/README_gl.md
+++ b/README_gl.md
@@ -5,7 +5,7 @@ NON debe editarse manualmente.
 
 # Facilmap para YunoHost
 
-[![Nivel de integración](https://dash.yunohost.org/integration/facilmap.svg)](https://dash.yunohost.org/appci/app/facilmap) ![Estado de funcionamento](https://ci-apps.yunohost.org/ci/badges/facilmap.status.svg) ![Estado de mantemento](https://ci-apps.yunohost.org/ci/badges/facilmap.maintain.svg)
+[![Nivel de integración](https://dash.yunohost.org/integration/facilmap.svg)](https://ci-apps.yunohost.org/ci/apps/facilmap/) ![Estado de funcionamento](https://ci-apps.yunohost.org/ci/badges/facilmap.status.svg) ![Estado de mantemento](https://ci-apps.yunohost.org/ci/badges/facilmap.maintain.svg)
 
 [![Instalar Facilmap con YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=facilmap)
 

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -5,7 +5,7 @@
 
 # YunoHost 上的 Facilmap
 
-[![集成程度](https://dash.yunohost.org/integration/facilmap.svg)](https://dash.yunohost.org/appci/app/facilmap) ![工作状态](https://ci-apps.yunohost.org/ci/badges/facilmap.status.svg) ![维护状态](https://ci-apps.yunohost.org/ci/badges/facilmap.maintain.svg)
+[![集成程度](https://dash.yunohost.org/integration/facilmap.svg)](https://ci-apps.yunohost.org/ci/apps/facilmap/) ![工作状态](https://ci-apps.yunohost.org/ci/badges/facilmap.status.svg) ![维护状态](https://ci-apps.yunohost.org/ci/badges/facilmap.maintain.svg)
 
 [![使用 YunoHost 安装 Facilmap](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=facilmap)
 

--- a/conf/config.env
+++ b/conf/config.env
@@ -8,6 +8,8 @@ USER_AGENT=__USER_AGENT__
 HOST=127.0.0.1
 PORT=__PORT__
 
+BASE_URL=https://__DOMAIN____PATH__
+
 # Database configuration. DB_TYPE can be mysql, postgres, sqlite or mssql.
 # See https://sequelize.org/master/class/lib/sequelize.js~Sequelize.html#instance-constructor-constructor for details.
 DB_TYPE=mysql

--- a/manifest.toml
+++ b/manifest.toml
@@ -87,8 +87,8 @@ ram.runtime = "450M"
     [resources.sources]
 
     [resources.sources.main]
-    url = "https://github.com/FacilMap/facilmap/archive/refs/tags/v4.1.1.tar.gz"
-    sha256 = "72cf9f7fbc6e9d5c73f7c1af02be63d2c5a99d13cf89c96af834db6004c89cf6"
+    url = "https://github.com/FacilMap/facilmap/archive/refs/tags/v4.1.2.tar.gz"
+    sha256 = "14995f31e93e703d867e6ac3e76f524e9a336a2321a8670058f07f4e3793699a"
     autoupdate.strategy = "latest_github_tag"
 
     [resources.ports]

--- a/scripts/install
+++ b/scripts/install
@@ -42,7 +42,8 @@ ynh_script_progression --message="Building $app..." --weight=10
 pushd "$install_dir"
     ynh_use_nodejs
     ynh_exec_warn_less env $ynh_node_load_PATH yarn install
-    ynh_exec_warn_less env $ynh_node_load_PATH yarn build   
+    ynh_exec_warn_less env $ynh_node_load_PATH yarn build:frontend:app
+    ynh_exec_warn_less env $ynh_node_load_PATH yarn build:server
 popd
 
 chmod 750 "$install_dir"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -44,7 +44,8 @@ ynh_script_progression --message="Install $app..." --weight=10
 pushd "$install_dir"
     ynh_use_nodejs
     ynh_exec_warn_less env $ynh_node_load_PATH yarn install
-    ynh_exec_warn_less env $ynh_node_load_PATH yarn build   
+    ynh_exec_warn_less env $ynh_node_load_PATH yarn build:frontend:app
+    ynh_exec_warn_less env $ynh_node_load_PATH yarn build:server
 popd
 
 chmod 750 "$install_dir"


### PR DESCRIPTION
## Problem

- JS/CSS resources are loaded from `/_app/`, causing failure if the app runs under a nested path (#25)

## Solution

- Upgrade to FacilMap 4.1.2 (includes a fix that embeds resources relatively, using `./_app/`)
- Set `BASE_URL` environment variable for places where absolute URLs are required (opensearch and oembed manifests)

Also changed the build script to only build the frontend and server modules, which should speed up installation.

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [X] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
